### PR TITLE
RSpec support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This module helps Cirrus CI to parse artifacts and find relative annotations to 
 
 * JUnit's XML
 * GolangCI's JSON
+* Android Lint
 * Create an [issue](https://github.com/cirruslabs/cirrus-ci-annotations/issues/new) to request support for other formats.
 
 # Contribution

--- a/annotations.go
+++ b/annotations.go
@@ -17,6 +17,8 @@ func ParseAnnotations(format string, path string) (error, []model.Annotation) {
 		return parsers.ParseGoLangCIAnnotations(path)
 	case "android-lint":
 		return parsers.ParseAndroidLintAnnotations(path)
+	case "rspec":
+		return parsers.ParseRSpecAnnotations(path)
 	default:
 		return nil, make([]model.Annotation, 0)
 	}

--- a/parsers/rspec.go
+++ b/parsers/rspec.go
@@ -1,0 +1,80 @@
+package parsers
+
+import (
+	"encoding/json"
+	"github.com/cirruslabs/cirrus-ci-annotations/model"
+	"io/ioutil"
+)
+
+type rspecException struct {
+	Message string
+}
+
+type rspecExample struct {
+	ID              string
+	Status          string
+	FullDescription string `json:"full_description"`
+	FilePath        string `json:"file_path"`
+	LineNumber      int64  `json:"line_number"`
+
+	// Used when status is "pending"
+	PendingMessage string `json:"pending_message"`
+
+	// Used when status is "failed"
+	Exception rspecException
+}
+
+type rspecReport struct {
+	Examples []rspecExample
+}
+
+// ParseRSpecAnnotations parses RSpec's JSON output into annotations according to the "spec" ranged from 3.0.0[1] to 3.9.2[2].
+// [1]: https://github.com/rspec/rspec-core/blob/v3.0.0/lib/rspec/core/example.rb
+// [2]: https://github.com/rspec/rspec-core/blob/v3.9.2/lib/rspec/core/example.rb
+func ParseRSpecAnnotations(path string) (error, []model.Annotation) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err, nil
+	}
+
+	var report rspecReport
+	err = json.Unmarshal(data, &report)
+	if err != nil {
+		return err, nil
+	}
+
+	result := make([]model.Annotation, 0)
+
+	for _, example := range report.Examples {
+		var level, rawDetails string
+
+		// Skip "passed" (which only adds noise) and deal with the rest of the states
+		switch example.Status {
+		case "pending":
+			level = "notice"
+			rawDetails = example.PendingMessage
+		case "failed":
+			level = "failure"
+			rawDetails = example.Exception.Message
+		default:
+			continue
+		}
+
+		var parsedAnnotation = model.Annotation{
+			Type:               model.TestResultAnnotationType,
+			Level:              level,
+			Message:            example.FullDescription,
+			RawDetails:         rawDetails,
+			FullyQualifiedName: example.ID,
+			Location: &model.FileLocation{
+				Path:      example.FilePath,
+				StartLine: example.LineNumber,
+				EndLine:   example.LineNumber,
+			},
+		}
+
+		result = append(result, parsedAnnotation)
+	}
+
+	return nil, result
+}

--- a/parsers/rspec_test.go
+++ b/parsers/rspec_test.go
@@ -1,0 +1,71 @@
+package parsers
+
+import (
+	"github.com/cirruslabs/cirrus-ci-annotations/model"
+	"github.com/go-test/deep"
+	"path/filepath"
+	"testing"
+)
+
+// Test_RSpec_MultipleStates ensures that "pending" and "failed" RSpec example states are handled properly,
+// while the "passed" state is skipped.
+//
+// The following dummy_spec.rb was used to generate the test data:
+//
+// class Dummy
+// end
+//
+// RSpec.describe Dummy do
+//   it "passes with deprecation warning" do
+//     expect {
+//       nil
+//     }.not_to raise_error(ArgumentError)
+//   end
+//
+//   it "gets skipped" do
+//     pending("not implemented yet")
+//     expect(1).to eq(2)
+//   end
+//
+//   it "fails" do
+//     expect(1).to eq(2)
+//   end
+// end
+func Test_RSpec_MultipleStates(t *testing.T) {
+	var expectedAnnotations = []model.Annotation{
+		{
+			Type:               model.TestResultAnnotationType,
+			Level:              "notice",
+			Message:            "Dummy gets skipped",
+			RawDetails:         "not implemented yet",
+			FullyQualifiedName: "./spec/dummy_spec.rb[1:2]",
+			Location: &model.FileLocation{
+				Path:      "./spec/dummy_spec.rb",
+				StartLine: 11,
+				EndLine:   11,
+			},
+		},
+		{
+			Type:               model.TestResultAnnotationType,
+			Level:              "failure",
+			Message:            "Dummy fails",
+			RawDetails:         "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+			FullyQualifiedName: "./spec/dummy_spec.rb[1:3]",
+			Location: &model.FileLocation{
+				Path:      "./spec/dummy_spec.rb",
+				StartLine: 16,
+				EndLine:   16,
+			},
+		},
+	}
+
+	err, gotAnnotations := ParseRSpecAnnotations(filepath.Join("..", "testdata", "json", "rspec.json"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if diff := deep.Equal(expectedAnnotations, gotAnnotations); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/testdata/json/rspec.json
+++ b/testdata/json/rspec.json
@@ -1,0 +1,85 @@
+{
+  "version": "3.9.2",
+  "examples": [
+    {
+      "id": "./spec/dummy_spec.rb[1:1]",
+      "description": "passes with deprecation warning",
+      "full_description": "Dummy passes with deprecation warning",
+      "status": "passed",
+      "file_path": "./spec/dummy_spec.rb",
+      "line_number": 5,
+      "run_time": 0.000710015,
+      "pending_message": null
+    },
+    {
+      "id": "./spec/dummy_spec.rb[1:2]",
+      "description": "gets skipped",
+      "full_description": "Dummy gets skipped",
+      "status": "pending",
+      "file_path": "./spec/dummy_spec.rb",
+      "line_number": 11,
+      "run_time": 0.00861102,
+      "pending_message": "not implemented yet"
+    },
+    {
+      "id": "./spec/dummy_spec.rb[1:3]",
+      "description": "fails",
+      "full_description": "Dummy fails",
+      "status": "failed",
+      "file_path": "./spec/dummy_spec.rb",
+      "line_number": 16,
+      "run_time": 0.000110567,
+      "pending_message": null,
+      "exception": {
+        "class": "RSpec::Expectations::ExpectationNotMetError",
+        "message": "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+        "backtrace": [
+          "/usr/local/bundle/gems/rspec-support-3.9.3/lib/rspec/support.rb:97:in `block in <module:Support>'",
+          "/usr/local/bundle/gems/rspec-support-3.9.3/lib/rspec/support.rb:106:in `notify_failure'",
+          "/usr/local/bundle/gems/rspec-expectations-3.9.2/lib/rspec/expectations/fail_with.rb:35:in `fail_with'",
+          "/usr/local/bundle/gems/rspec-expectations-3.9.2/lib/rspec/expectations/handler.rb:38:in `handle_failure'",
+          "/usr/local/bundle/gems/rspec-expectations-3.9.2/lib/rspec/expectations/handler.rb:50:in `block in handle_matcher'",
+          "/usr/local/bundle/gems/rspec-expectations-3.9.2/lib/rspec/expectations/handler.rb:27:in `with_matcher'",
+          "/usr/local/bundle/gems/rspec-expectations-3.9.2/lib/rspec/expectations/handler.rb:48:in `handle_matcher'",
+          "/usr/local/bundle/gems/rspec-expectations-3.9.2/lib/rspec/expectations/expectation_target.rb:65:in `to'",
+          "/app/spec/dummy_spec.rb:17:in `block (2 levels) in <top (required)>'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example.rb:257:in `instance_exec'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example.rb:257:in `block in run'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example.rb:503:in `block in with_around_and_singleton_context_hooks'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example.rb:460:in `block in with_around_example_hooks'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/hooks.rb:481:in `block in run'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/hooks.rb:619:in `run_around_example_hooks_for'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/hooks.rb:481:in `run'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example.rb:460:in `with_around_example_hooks'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example.rb:503:in `with_around_and_singleton_context_hooks'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example.rb:254:in `run'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example_group.rb:644:in `block in run_examples'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example_group.rb:640:in `map'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example_group.rb:640:in `run_examples'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/example_group.rb:606:in `run'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/runner.rb:121:in `block (3 levels) in run_specs'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/runner.rb:121:in `map'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/runner.rb:121:in `block (2 levels) in run_specs'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/configuration.rb:2058:in `with_suite_hooks'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/runner.rb:116:in `block in run_specs'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/reporter.rb:74:in `report'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/runner.rb:115:in `run_specs'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/runner.rb:89:in `run'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/runner.rb:71:in `run'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/lib/rspec/core/runner.rb:45:in `invoke'",
+          "/usr/local/bundle/gems/rspec-core-3.9.2/exe/rspec:4:in `<top (required)>'",
+          "/usr/local/bundle/bin/rspec:23:in `load'",
+          "/usr/local/bundle/bin/rspec:23:in `<main>'"
+        ]
+      }
+    }
+  ],
+  "summary": {
+    "duration": 0.010073845,
+    "example_count": 3,
+    "failure_count": 1,
+    "pending_count": 1,
+    "errors_outside_of_examples_count": 0
+  },
+  "summary_line": "3 examples, 1 failure, 1 pending"
+}


### PR DESCRIPTION
A gateway to cirruslabs#10 completion.

Only 3.* is supported for now, but considering that latest 2.* [was released 6 years ago](https://rubygems.org/gems/rspec/versions), this should be a pretty good start.

Also contains a little README.md bit for 0d98c783ca213d7203303b3a5cfc6c4b3865ba0a.