### PR TITLE
rspec: normalize file paths

### DIFF
--- a/parsers/rspec.go
+++ b/parsers/rspec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/cirruslabs/cirrus-ci-annotations/model"
 	"io/ioutil"
+	"path/filepath"
 )
 
 type rspecException struct {
@@ -67,7 +68,7 @@ func ParseRSpecAnnotations(path string) (error, []model.Annotation) {
 			RawDetails:         rawDetails,
 			FullyQualifiedName: example.ID,
 			Location: &model.FileLocation{
-				Path:      example.FilePath,
+				Path:      filepath.Clean(example.FilePath),
 				StartLine: example.LineNumber,
 				EndLine:   example.LineNumber,
 			},

--- a/parsers/rspec_test.go
+++ b/parsers/rspec_test.go
@@ -40,7 +40,7 @@ func Test_RSpec_MultipleStates(t *testing.T) {
 			RawDetails:         "not implemented yet",
 			FullyQualifiedName: "./spec/dummy_spec.rb[1:2]",
 			Location: &model.FileLocation{
-				Path:      "./spec/dummy_spec.rb",
+				Path:      "spec/dummy_spec.rb",
 				StartLine: 11,
 				EndLine:   11,
 			},
@@ -52,7 +52,7 @@ func Test_RSpec_MultipleStates(t *testing.T) {
 			RawDetails:         "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
 			FullyQualifiedName: "./spec/dummy_spec.rb[1:3]",
 			Location: &model.FileLocation{
-				Path:      "./spec/dummy_spec.rb",
+				Path:      "spec/dummy_spec.rb",
 				StartLine: 16,
 				EndLine:   16,
 			},


### PR DESCRIPTION
The rest of the parsers seem to be emitting already normalized paths (whether absolute or relative).

See #10 discussion.