### PR TITLE
Improve annotation model

### DIFF
--- a/model/annotation.go
+++ b/model/annotation.go
@@ -1,5 +1,28 @@
 package model
 
+import "fmt"
+
+type AnnotationLevel int
+
+const (
+	LevelNotice AnnotationLevel = iota
+	LevelWarning
+	LevelFailure
+)
+
+func (al *AnnotationLevel) String() string {
+	switch *al {
+	case LevelNotice:
+		return "notice"
+	case LevelWarning:
+		return "warning"
+	case LevelFailure:
+		return "failure"
+	default:
+		panic(fmt.Sprintf("unhandled annotation level: %d", *al))
+	}
+}
+
 type FileLocation struct {
 	Path        string
 	StartLine   int64
@@ -10,7 +33,7 @@ type FileLocation struct {
 
 // mimics https://developer.github.com/v3/checks/runs/#annotations-object
 type Annotation struct {
-	Level              string
+	Level              AnnotationLevel
 	Message            string
 	RawDetails         string
 	Location           *FileLocation

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -1,14 +1,5 @@
 package model
 
-type AnnotationType int32
-
-const (
-	GenericAnnotationType    AnnotationType = 0
-	TestResultAnnotationType AnnotationType = 1
-	LintResultAnnotationType AnnotationType = 2
-	AnalysysAnnotationType   AnnotationType = 3
-)
-
 type FileLocation struct {
 	Path        string
 	StartLine   int64
@@ -19,10 +10,8 @@ type FileLocation struct {
 
 // mimics https://developer.github.com/v3/checks/runs/#annotations-object
 type Annotation struct {
-	Type               AnnotationType
 	Level              string
 	Message            string
 	RawDetails         string
-	FullyQualifiedName string
 	Location           *FileLocation
 }

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -33,8 +33,8 @@ type FileLocation struct {
 
 // mimics https://developer.github.com/v3/checks/runs/#annotations-object
 type Annotation struct {
-	Level              AnnotationLevel
-	Message            string
-	RawDetails         string
-	Location           *FileLocation
+	Level      AnnotationLevel
+	Message    string
+	RawDetails string
+	Location   *FileLocation
 }

--- a/parsers/android_lint.go
+++ b/parsers/android_lint.go
@@ -13,11 +13,11 @@ const supportedFormatVersion = 5
 // severityMapping maps Android Lint severity to Github's annotation level
 // https://android.googlesource.com/platform/tools/base/+/studio-master-dev/lint/libs/lint-api/src/main/java/com/android/tools/lint/detector/api/Severity.kt
 // we leave out the Ignore severity type as we don't want to report it
-var severityMapping = map[string]string{
-	"Fatal":       "fatal",
-	"Error":       "fatal",
-	"Warning":     "warning",
-	"Information": "notice",
+var severityMapping = map[string]model.AnnotationLevel{
+	"Fatal":       model.LevelFailure,
+	"Error":       model.LevelFailure,
+	"Warning":     model.LevelWarning,
+	"Information": model.LevelNotice,
 }
 
 type androidLintReport struct {

--- a/parsers/android_lint.go
+++ b/parsers/android_lint.go
@@ -69,9 +69,9 @@ func ParseAndroidLintAnnotations(path string) (error, []model.Annotation) {
 		if found {
 			for _, location := range issue.Locations {
 				var parsedAnnotation = model.Annotation{
-					Level:              level,
-					Message:            issue.Message,
-					RawDetails:         issue.Explanation,
+					Level:      level,
+					Message:    issue.Message,
+					RawDetails: issue.Explanation,
 					Location: &model.FileLocation{
 						Path:        location.Filename,
 						StartLine:   location.Line,

--- a/parsers/android_lint.go
+++ b/parsers/android_lint.go
@@ -69,9 +69,7 @@ func ParseAndroidLintAnnotations(path string) (error, []model.Annotation) {
 		if found {
 			for _, location := range issue.Locations {
 				var parsedAnnotation = model.Annotation{
-					Type:               model.LintResultAnnotationType,
 					Level:              level,
-					FullyQualifiedName: issue.ID,
 					Message:            issue.Message,
 					RawDetails:         issue.Explanation,
 					Location: &model.FileLocation{

--- a/parsers/android_lint_test.go
+++ b/parsers/android_lint_test.go
@@ -19,9 +19,9 @@ func Test_AndroidLint_Multiple_Locations(t *testing.T) {
 
 	firstAnnotation := annotations[0]
 	firstExpected := model.Annotation{
-		Level:              model.LevelWarning,
-		Message:            "The resource `R.string.my_string` appears to be unused",
-		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
+		Level:      model.LevelWarning,
+		Message:    "The resource `R.string.my_string` appears to be unused",
+		RawDetails: "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-de/strings.xml",
 			StartLine:   35,
@@ -37,9 +37,9 @@ func Test_AndroidLint_Multiple_Locations(t *testing.T) {
 
 	secondAnnotation := annotations[1]
 	secondExpected := model.Annotation{
-		Level:              model.LevelWarning,
-		Message:            "The resource `R.string.my_string` appears to be unused",
-		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
+		Level:      model.LevelWarning,
+		Message:    "The resource `R.string.my_string` appears to be unused",
+		RawDetails: "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-fr/strings.xml",
 			StartLine:   37,
@@ -65,9 +65,9 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	firstAnnotation := annotations[0]
 	firstExpected := model.Annotation{
-		Level:              model.LevelFailure,
-		Message:            "The resource `R.string.my_string` appears to be unused",
-		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
+		Level:      model.LevelFailure,
+		Message:    "The resource `R.string.my_string` appears to be unused",
+		RawDetails: "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-de/strings.xml",
 			StartLine:   35,
@@ -83,9 +83,9 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	secondAnnotation := annotations[1]
 	secondExpected := model.Annotation{
-		Level:              model.LevelFailure,
-		Message:            "The resource `R.string.my_string` appears to be unused",
-		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
+		Level:      model.LevelFailure,
+		Message:    "The resource `R.string.my_string` appears to be unused",
+		RawDetails: "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-de/strings.xml",
 			StartLine:   35,
@@ -101,9 +101,9 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	thirdAnnotation := annotations[2]
 	thirdExpected := model.Annotation{
-		Level:              model.LevelNotice,
-		Message:            "The resource `R.string.my_string` appears to be unused",
-		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
+		Level:      model.LevelNotice,
+		Message:    "The resource `R.string.my_string` appears to be unused",
+		RawDetails: "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-de/strings.xml",
 			StartLine:   35,

--- a/parsers/android_lint_test.go
+++ b/parsers/android_lint_test.go
@@ -19,10 +19,8 @@ func Test_AndroidLint_Multiple_Locations(t *testing.T) {
 
 	firstAnnotation := annotations[0]
 	firstExpected := model.Annotation{
-		Type:               model.LintResultAnnotationType,
 		Level:              "warning",
 		Message:            "The resource `R.string.my_string` appears to be unused",
-		FullyQualifiedName: "UnusedResources",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-de/strings.xml",
@@ -39,10 +37,8 @@ func Test_AndroidLint_Multiple_Locations(t *testing.T) {
 
 	secondAnnotation := annotations[1]
 	secondExpected := model.Annotation{
-		Type:               model.LintResultAnnotationType,
 		Level:              "warning",
 		Message:            "The resource `R.string.my_string` appears to be unused",
-		FullyQualifiedName: "UnusedResources",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-fr/strings.xml",
@@ -69,10 +65,8 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	firstAnnotation := annotations[0]
 	firstExpected := model.Annotation{
-		Type:               model.LintResultAnnotationType,
 		Level:              "fatal",
 		Message:            "The resource `R.string.my_string` appears to be unused",
-		FullyQualifiedName: "UnusedResources",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-de/strings.xml",
@@ -89,10 +83,8 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	secondAnnotation := annotations[1]
 	secondExpected := model.Annotation{
-		Type:               model.LintResultAnnotationType,
 		Level:              "fatal",
 		Message:            "The resource `R.string.my_string` appears to be unused",
-		FullyQualifiedName: "UnusedResources",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-de/strings.xml",
@@ -109,10 +101,8 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	thirdAnnotation := annotations[2]
 	thirdExpected := model.Annotation{
-		Type:               model.LintResultAnnotationType,
 		Level:              "notice",
 		Message:            "The resource `R.string.my_string` appears to be unused",
-		FullyQualifiedName: "UnusedResources",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
 			Path:        "/path/to/project/app/src/main/res/values-de/strings.xml",

--- a/parsers/android_lint_test.go
+++ b/parsers/android_lint_test.go
@@ -19,7 +19,7 @@ func Test_AndroidLint_Multiple_Locations(t *testing.T) {
 
 	firstAnnotation := annotations[0]
 	firstExpected := model.Annotation{
-		Level:              "warning",
+		Level:              model.LevelWarning,
 		Message:            "The resource `R.string.my_string` appears to be unused",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
@@ -37,7 +37,7 @@ func Test_AndroidLint_Multiple_Locations(t *testing.T) {
 
 	secondAnnotation := annotations[1]
 	secondExpected := model.Annotation{
-		Level:              "warning",
+		Level:              model.LevelWarning,
 		Message:            "The resource `R.string.my_string` appears to be unused",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
@@ -65,7 +65,7 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	firstAnnotation := annotations[0]
 	firstExpected := model.Annotation{
-		Level:              "fatal",
+		Level:              model.LevelFailure,
 		Message:            "The resource `R.string.my_string` appears to be unused",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
@@ -83,7 +83,7 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	secondAnnotation := annotations[1]
 	secondExpected := model.Annotation{
-		Level:              "fatal",
+		Level:              model.LevelFailure,
 		Message:            "The resource `R.string.my_string` appears to be unused",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{
@@ -101,7 +101,7 @@ func Test_AndroidLint_Multiple_Issues(t *testing.T) {
 
 	thirdAnnotation := annotations[2]
 	thirdExpected := model.Annotation{
-		Level:              "notice",
+		Level:              model.LevelNotice,
 		Message:            "The resource `R.string.my_string` appears to be unused",
 		RawDetails:         "Unused resources make applications larger and slow down builds.\n\nThe unused resource check can ignore tests. If you want to include resources that are only referenced from tests, consider packaging them in a test source set instead.\n\nYou can include test sources in the unused resource check by setting the system property lint.unused-resources.include-tests=true, and to exclude them (usually for performance reasons), use lint.unused-resources.exclude-tests=true.",
 		Location: &model.FileLocation{

--- a/parsers/flutter.go
+++ b/parsers/flutter.go
@@ -71,7 +71,7 @@ func ParseFlutterAnnotations(path string) (error, []model.Annotation) {
 		case "testDone":
 			if entry.Result != "success" {
 				if annotation, ok := runningTests[entry.TestID]; ok {
-					annotation.Level = "failure"
+					annotation.Level = model.LevelFailure
 					result = append(result, *annotation)
 					delete(runningTests, entry.TestID)
 				}

--- a/parsers/flutter.go
+++ b/parsers/flutter.go
@@ -26,7 +26,6 @@ type flutterEntry struct {
 
 func annotationFromTest(test *flutterTest) *model.Annotation {
 	return &model.Annotation{
-		Type:    model.TestResultAnnotationType,
 		Message: test.Name,
 		Location: &model.FileLocation{
 			Path:        strings.TrimPrefix(test.URL, "file://"),

--- a/parsers/flutter_test.go
+++ b/parsers/flutter_test.go
@@ -20,7 +20,7 @@ func TestFlutterSucceeding(t *testing.T) {
 func TestFlutterFailing(t *testing.T) {
 	expected := []model.Annotation{
 		{
-			Level:      "failure",
+			Level:      model.LevelFailure,
 			Message:    "Counter value should start at 0",
 			RawDetails: "Expected: <0>\n  Actual: <1>\n",
 			Location: &model.FileLocation{
@@ -32,7 +32,7 @@ func TestFlutterFailing(t *testing.T) {
 			},
 		},
 		{
-			Level:      "failure",
+			Level:      model.LevelFailure,
 			Message:    "Counter value should be incremented",
 			RawDetails: "Expected: <1>\n  Actual: <2>\n",
 			Location: &model.FileLocation{
@@ -44,7 +44,7 @@ func TestFlutterFailing(t *testing.T) {
 			},
 		},
 		{
-			Level:   "failure",
+			Level:   model.LevelFailure,
 			Message: "Counter value should be decremented",
 			RawDetails: "Expected: <-1>\n  Actual: <0>\n",
 			Location: &model.FileLocation{

--- a/parsers/flutter_test.go
+++ b/parsers/flutter_test.go
@@ -20,9 +20,8 @@ func TestFlutterSucceeding(t *testing.T) {
 func TestFlutterFailing(t *testing.T) {
 	expected := []model.Annotation{
 		{
-			Type:    model.TestResultAnnotationType,
-			Level:   "failure",
-			Message: "Counter value should start at 0",
+			Level:      "failure",
+			Message:    "Counter value should start at 0",
 			RawDetails: "Expected: <0>\n  Actual: <1>\n",
 			Location: &model.FileLocation{
 				Path:        "/tmp/cirrus-ci-build/test/counter_test.dart",
@@ -33,9 +32,8 @@ func TestFlutterFailing(t *testing.T) {
 			},
 		},
 		{
-			Type:    model.TestResultAnnotationType,
-			Level:   "failure",
-			Message: "Counter value should be incremented",
+			Level:      "failure",
+			Message:    "Counter value should be incremented",
 			RawDetails: "Expected: <1>\n  Actual: <2>\n",
 			Location: &model.FileLocation{
 				Path:        "/tmp/cirrus-ci-build/test/counter_test.dart",
@@ -46,7 +44,6 @@ func TestFlutterFailing(t *testing.T) {
 			},
 		},
 		{
-			Type:    model.TestResultAnnotationType,
 			Level:   "failure",
 			Message: "Counter value should be decremented",
 			RawDetails: "Expected: <-1>\n  Actual: <0>\n",

--- a/parsers/flutter_test.go
+++ b/parsers/flutter_test.go
@@ -44,8 +44,8 @@ func TestFlutterFailing(t *testing.T) {
 			},
 		},
 		{
-			Level:   model.LevelFailure,
-			Message: "Counter value should be decremented",
+			Level:      model.LevelFailure,
+			Message:    "Counter value should be decremented",
 			RawDetails: "Expected: <-1>\n  Actual: <0>\n",
 			Location: &model.FileLocation{
 				Path:        "/tmp/cirrus-ci-build/test/counter_test.dart",

--- a/parsers/golangci.go
+++ b/parsers/golangci.go
@@ -38,8 +38,8 @@ func ParseGoLangCIAnnotations(path string) (error, []model.Annotation) {
 	result := make([]model.Annotation, 0)
 	for _, issue := range report.Issues {
 		var parsedAnnotation = model.Annotation{
-			Level:              model.LevelFailure,
-			Message:            fmt.Sprintf("%s (%s)", issue.Text, issue.FromLinter),
+			Level:   model.LevelFailure,
+			Message: fmt.Sprintf("%s (%s)", issue.Text, issue.FromLinter),
 			Location: &model.FileLocation{
 				Path:        issue.Pos.Filename,
 				StartLine:   issue.Pos.Line,

--- a/parsers/golangci.go
+++ b/parsers/golangci.go
@@ -38,9 +38,7 @@ func ParseGoLangCIAnnotations(path string) (error, []model.Annotation) {
 	result := make([]model.Annotation, 0)
 	for _, issue := range report.Issues {
 		var parsedAnnotation = model.Annotation{
-			Type:               model.TestResultAnnotationType,
 			Level:              "failure",
-			FullyQualifiedName: issue.FromLinter,
 			Message:            fmt.Sprintf("%s (%s)", issue.Text, issue.FromLinter),
 			Location: &model.FileLocation{
 				Path:        issue.Pos.Filename,

--- a/parsers/golangci.go
+++ b/parsers/golangci.go
@@ -38,7 +38,7 @@ func ParseGoLangCIAnnotations(path string) (error, []model.Annotation) {
 	result := make([]model.Annotation, 0)
 	for _, issue := range report.Issues {
 		var parsedAnnotation = model.Annotation{
-			Level:              "failure",
+			Level:              model.LevelFailure,
 			Message:            fmt.Sprintf("%s (%s)", issue.Text, issue.FromLinter),
 			Location: &model.FileLocation{
 				Path:        issue.Pos.Filename,

--- a/parsers/golangci_test.go
+++ b/parsers/golangci_test.go
@@ -18,10 +18,8 @@ func Test_GoLangCI(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Type:               model.TestResultAnnotationType,
 		Level:              "failure",
 		Message:            "S1007: should use raw string (`...`) with regexp.Compile to avoid having to escape twice (gosimple)",
-		FullyQualifiedName: "gosimple",
 		RawDetails:         "",
 		Location: &model.FileLocation{
 			Path:        "util/location.go",

--- a/parsers/golangci_test.go
+++ b/parsers/golangci_test.go
@@ -18,9 +18,9 @@ func Test_GoLangCI(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Level:              model.LevelFailure,
-		Message:            "S1007: should use raw string (`...`) with regexp.Compile to avoid having to escape twice (gosimple)",
-		RawDetails:         "",
+		Level:      model.LevelFailure,
+		Message:    "S1007: should use raw string (`...`) with regexp.Compile to avoid having to escape twice (gosimple)",
+		RawDetails: "",
 		Location: &model.FileLocation{
 			Path:        "util/location.go",
 			StartLine:   11,

--- a/parsers/golangci_test.go
+++ b/parsers/golangci_test.go
@@ -18,7 +18,7 @@ func Test_GoLangCI(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Level:              "failure",
+		Level:              model.LevelFailure,
 		Message:            "S1007: should use raw string (`...`) with regexp.Compile to avoid having to escape twice (gosimple)",
 		RawDetails:         "",
 		Location: &model.FileLocation{

--- a/parsers/junit.go
+++ b/parsers/junit.go
@@ -21,17 +21,13 @@ func ParseJUnitAnnotations(path string) (error, []model.Annotation) {
 			switch test.Status {
 			case junit.StatusPassed:
 				parsedAnnotation = model.Annotation{
-					Type:               model.TestResultAnnotationType,
 					Level:              "notice",
 					Message:            fqn,
-					FullyQualifiedName: fqn,
 				}
 			case junit.StatusFailed:
 				parsedAnnotation = model.Annotation{
-					Type:               model.TestResultAnnotationType,
 					Level:              "failure",
 					Message:            fqn,
-					FullyQualifiedName: fqn,
 					RawDetails:         test.Error.Error(),
 					Location: util.GuessLocationIgnored(
 						test.Error.Error(),

--- a/parsers/junit.go
+++ b/parsers/junit.go
@@ -21,14 +21,14 @@ func ParseJUnitAnnotations(path string) (error, []model.Annotation) {
 			switch test.Status {
 			case junit.StatusPassed:
 				parsedAnnotation = model.Annotation{
-					Level:              model.LevelNotice,
-					Message:            fqn,
+					Level:   model.LevelNotice,
+					Message: fqn,
 				}
 			case junit.StatusFailed:
 				parsedAnnotation = model.Annotation{
-					Level:              model.LevelFailure,
-					Message:            fqn,
-					RawDetails:         test.Error.Error(),
+					Level:      model.LevelFailure,
+					Message:    fqn,
+					RawDetails: test.Error.Error(),
 					Location: util.GuessLocationIgnored(
 						test.Error.Error(),
 						[]string{

--- a/parsers/junit.go
+++ b/parsers/junit.go
@@ -21,12 +21,12 @@ func ParseJUnitAnnotations(path string) (error, []model.Annotation) {
 			switch test.Status {
 			case junit.StatusPassed:
 				parsedAnnotation = model.Annotation{
-					Level:              "notice",
+					Level:              model.LevelNotice,
 					Message:            fqn,
 				}
 			case junit.StatusFailed:
 				parsedAnnotation = model.Annotation{
-					Level:              "failure",
+					Level:              model.LevelFailure,
 					Message:            fqn,
 					RawDetails:         test.Error.Error(),
 					Location: util.GuessLocationIgnored(

--- a/parsers/junit_test.go
+++ b/parsers/junit_test.go
@@ -18,9 +18,9 @@ func Test_JunitJava(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Level:              model.LevelFailure,
-		Message:            "LibraryTest.testSomeLibraryMethod",
-		RawDetails:         "",
+		Level:      model.LevelFailure,
+		Message:    "LibraryTest.testSomeLibraryMethod",
+		RawDetails: "",
 		Location: &model.FileLocation{
 			Path:      "LibraryTest.java",
 			StartLine: 10,
@@ -44,9 +44,9 @@ func Test_JunitKotlin(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Level:              model.LevelFailure,
-		Message:            "com.fkorotkov.kubernetes.SimpleCompilationTest.testService",
-		RawDetails:         "",
+		Level:      model.LevelFailure,
+		Message:    "com.fkorotkov.kubernetes.SimpleCompilationTest.testService",
+		RawDetails: "",
 		Location: &model.FileLocation{
 			Path:      "SimpleCompilationTest.kt",
 			StartLine: 41,
@@ -70,9 +70,9 @@ func Test_PythonXMLRunner(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Level:              model.LevelFailure,
-		Message:            "tests.Tests.test_utilities",
-		RawDetails:         "",
+		Level:      model.LevelFailure,
+		Message:    "tests.Tests.test_utilities",
+		RawDetails: "",
 		Location: &model.FileLocation{
 			Path:      "tests.py",
 			StartLine: 70,

--- a/parsers/junit_test.go
+++ b/parsers/junit_test.go
@@ -18,7 +18,7 @@ func Test_JunitJava(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Level:              "failure",
+		Level:              model.LevelFailure,
 		Message:            "LibraryTest.testSomeLibraryMethod",
 		RawDetails:         "",
 		Location: &model.FileLocation{
@@ -44,7 +44,7 @@ func Test_JunitKotlin(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Level:              "failure",
+		Level:              model.LevelFailure,
 		Message:            "com.fkorotkov.kubernetes.SimpleCompilationTest.testService",
 		RawDetails:         "",
 		Location: &model.FileLocation{
@@ -70,7 +70,7 @@ func Test_PythonXMLRunner(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Level:              "failure",
+		Level:              model.LevelFailure,
 		Message:            "tests.Tests.test_utilities",
 		RawDetails:         "",
 		Location: &model.FileLocation{

--- a/parsers/junit_test.go
+++ b/parsers/junit_test.go
@@ -18,10 +18,8 @@ func Test_JunitJava(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Type:               model.TestResultAnnotationType,
 		Level:              "failure",
 		Message:            "LibraryTest.testSomeLibraryMethod",
-		FullyQualifiedName: "LibraryTest.testSomeLibraryMethod",
 		RawDetails:         "",
 		Location: &model.FileLocation{
 			Path:      "LibraryTest.java",
@@ -46,10 +44,8 @@ func Test_JunitKotlin(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Type:               model.TestResultAnnotationType,
 		Level:              "failure",
 		Message:            "com.fkorotkov.kubernetes.SimpleCompilationTest.testService",
-		FullyQualifiedName: "com.fkorotkov.kubernetes.SimpleCompilationTest.testService",
 		RawDetails:         "",
 		Location: &model.FileLocation{
 			Path:      "SimpleCompilationTest.kt",
@@ -74,10 +70,8 @@ func Test_PythonXMLRunner(t *testing.T) {
 	annotation := annotations[0]
 	annotation.RawDetails = ""
 	expected := model.Annotation{
-		Type:               model.TestResultAnnotationType,
 		Level:              "failure",
 		Message:            "tests.Tests.test_utilities",
-		FullyQualifiedName: "tests.Tests.test_utilities",
 		RawDetails:         "",
 		Location: &model.FileLocation{
 			Path:      "tests.py",

--- a/parsers/qodana.go
+++ b/parsers/qodana.go
@@ -25,16 +25,16 @@ type qodanaReport struct {
 	ListProblem []qodanaProblem
 }
 
-func qodanaSeverityToAnnotationLevel(severity string) string {
+func qodanaSeverityToAnnotationLevel(severity string) model.AnnotationLevel {
 	switch strings.ToLower(severity) {
 	case "critical":
-		return "failure"
+		return model.LevelFailure
 	case "high":
 		fallthrough
 	case "moderate":
-		return "warning"
+		return model.LevelWarning
 	default:
-		return "notice"
+		return model.LevelNotice
 	}
 }
 

--- a/parsers/qodana_test.go
+++ b/parsers/qodana_test.go
@@ -11,7 +11,7 @@ import (
 func TestQodana(t *testing.T) {
 	expected := []model.Annotation{
 		{
-			Level:   "failure",
+			Level:   model.LevelFailure,
 			Message: "Cannot resolve symbol 'ComponentSelection' ",
 			RawDetails: `<html>
 <body>
@@ -27,7 +27,7 @@ Allows you to see problems reported by language annotators in the results of bat
 			},
 		},
 		{
-			Level:   "failure",
+			Level:   model.LevelFailure,
 			Message: "Cannot resolve symbol 'FileType' ",
 			RawDetails: `<html>
 <body>
@@ -43,7 +43,7 @@ Allows you to see problems reported by language annotators in the results of bat
 			},
 		},
 		{
-			Level:   "failure",
+			Level:   model.LevelFailure,
 			Message: "Cannot resolve symbol 'FileVisitResult' ",
 			RawDetails: `<html>
 <body>
@@ -59,7 +59,7 @@ Allows you to see problems reported by language annotators in the results of bat
 			},
 		},
 		{
-			Level:   "failure",
+			Level:   model.LevelFailure,
 			Message: "Cannot resolve symbol 'FileVisitResult' ",
 			RawDetails: `<html>
 <body>
@@ -75,7 +75,7 @@ Allows you to see problems reported by language annotators in the results of bat
 			},
 		},
 		{
-			Level:   "warning",
+			Level:   model.LevelWarning,
 			Message: "Kotlin version that is used for building with Gradle (1.3.72) differs from the one bundled into the IDE plugin (1.4.10)",
 			RawDetails: `<html>
 <body>

--- a/parsers/rspec.go
+++ b/parsers/rspec.go
@@ -62,11 +62,9 @@ func ParseRSpecAnnotations(path string) (error, []model.Annotation) {
 		}
 
 		var parsedAnnotation = model.Annotation{
-			Type:               model.TestResultAnnotationType,
 			Level:              level,
 			Message:            example.FullDescription,
 			RawDetails:         rawDetails,
-			FullyQualifiedName: example.ID,
 			Location: &model.FileLocation{
 				Path:      filepath.Clean(example.FilePath),
 				StartLine: example.LineNumber,

--- a/parsers/rspec.go
+++ b/parsers/rspec.go
@@ -63,9 +63,9 @@ func ParseRSpecAnnotations(path string) (error, []model.Annotation) {
 		}
 
 		var parsedAnnotation = model.Annotation{
-			Level:              level,
-			Message:            example.FullDescription,
-			RawDetails:         rawDetails,
+			Level:      level,
+			Message:    example.FullDescription,
+			RawDetails: rawDetails,
 			Location: &model.FileLocation{
 				Path:      filepath.Clean(example.FilePath),
 				StartLine: example.LineNumber,

--- a/parsers/rspec.go
+++ b/parsers/rspec.go
@@ -47,15 +47,16 @@ func ParseRSpecAnnotations(path string) (error, []model.Annotation) {
 	result := make([]model.Annotation, 0)
 
 	for _, example := range report.Examples {
-		var level, rawDetails string
+		var level model.AnnotationLevel
+		var rawDetails string
 
 		// Skip "passed" (which only adds noise) and deal with the rest of the states
 		switch example.Status {
 		case "pending":
-			level = "notice"
+			level = model.LevelNotice
 			rawDetails = example.PendingMessage
 		case "failed":
-			level = "failure"
+			level = model.LevelFailure
 			rawDetails = example.Exception.Message
 		default:
 			continue

--- a/parsers/rspec_test.go
+++ b/parsers/rspec_test.go
@@ -34,7 +34,7 @@ import (
 func Test_RSpec_MultipleStates(t *testing.T) {
 	var expectedAnnotations = []model.Annotation{
 		{
-			Level:              "notice",
+			Level:              model.LevelNotice,
 			Message:            "Dummy gets skipped",
 			RawDetails:         "not implemented yet",
 			Location: &model.FileLocation{
@@ -44,7 +44,7 @@ func Test_RSpec_MultipleStates(t *testing.T) {
 			},
 		},
 		{
-			Level:              "failure",
+			Level:              model.LevelFailure,
 			Message:            "Dummy fails",
 			RawDetails:         "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
 			Location: &model.FileLocation{

--- a/parsers/rspec_test.go
+++ b/parsers/rspec_test.go
@@ -34,11 +34,9 @@ import (
 func Test_RSpec_MultipleStates(t *testing.T) {
 	var expectedAnnotations = []model.Annotation{
 		{
-			Type:               model.TestResultAnnotationType,
 			Level:              "notice",
 			Message:            "Dummy gets skipped",
 			RawDetails:         "not implemented yet",
-			FullyQualifiedName: "./spec/dummy_spec.rb[1:2]",
 			Location: &model.FileLocation{
 				Path:      "spec/dummy_spec.rb",
 				StartLine: 11,
@@ -46,11 +44,9 @@ func Test_RSpec_MultipleStates(t *testing.T) {
 			},
 		},
 		{
-			Type:               model.TestResultAnnotationType,
 			Level:              "failure",
 			Message:            "Dummy fails",
 			RawDetails:         "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
-			FullyQualifiedName: "./spec/dummy_spec.rb[1:3]",
 			Location: &model.FileLocation{
 				Path:      "spec/dummy_spec.rb",
 				StartLine: 16,

--- a/parsers/rspec_test.go
+++ b/parsers/rspec_test.go
@@ -34,9 +34,9 @@ import (
 func Test_RSpec_MultipleStates(t *testing.T) {
 	var expectedAnnotations = []model.Annotation{
 		{
-			Level:              model.LevelNotice,
-			Message:            "Dummy gets skipped",
-			RawDetails:         "not implemented yet",
+			Level:      model.LevelNotice,
+			Message:    "Dummy gets skipped",
+			RawDetails: "not implemented yet",
 			Location: &model.FileLocation{
 				Path:      "spec/dummy_spec.rb",
 				StartLine: 11,
@@ -44,9 +44,9 @@ func Test_RSpec_MultipleStates(t *testing.T) {
 			},
 		},
 		{
-			Level:              model.LevelFailure,
-			Message:            "Dummy fails",
-			RawDetails:         "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
+			Level:      model.LevelFailure,
+			Message:    "Dummy fails",
+			RawDetails: "\nexpected: 2\n     got: 1\n\n(compared using ==)\n",
 			Location: &model.FileLocation{
 				Path:      "spec/dummy_spec.rb",
 				StartLine: 16,

--- a/parsers/rubocop.go
+++ b/parsers/rubocop.go
@@ -60,7 +60,7 @@ func ParseRuboCopAnnotations(path string) (error, []model.Annotation) {
 	result := make([]model.Annotation, 0)
 
 	for _, file := range report.Files {
-		for offenseNumber, offense := range file.Offenses {
+		for _, offense := range file.Offenses {
 			// Map RuboCop's severity to GitHub's annotation level,
 			// skipping unknown severities.
 			level, found := rubocopSeverityMapping[offense.Severity]
@@ -73,14 +73,9 @@ func ParseRuboCopAnnotations(path string) (error, []model.Annotation) {
 				level = "notice"
 			}
 
-			// RuboCop does not provide a FQN, so we craft one ourselves
-			fqn := fmt.Sprintf("%s-%d", file.Path, offenseNumber)
-
 			var parsedAnnotation = model.Annotation{
-				Type:               model.LintResultAnnotationType,
 				Level:              level,
 				Message:            fmt.Sprintf("%s: %s", offense.CopName, offense.Message),
-				FullyQualifiedName: fqn,
 				Location: &model.FileLocation{
 					Path:        file.Path,
 					StartLine:   offense.Location.Line,

--- a/parsers/rubocop.go
+++ b/parsers/rubocop.go
@@ -74,8 +74,8 @@ func ParseRuboCopAnnotations(path string) (error, []model.Annotation) {
 			}
 
 			var parsedAnnotation = model.Annotation{
-				Level:              level,
-				Message:            fmt.Sprintf("%s: %s", offense.CopName, offense.Message),
+				Level:   level,
+				Message: fmt.Sprintf("%s: %s", offense.CopName, offense.Message),
 				Location: &model.FileLocation{
 					Path:        file.Path,
 					StartLine:   offense.Location.Line,

--- a/parsers/rubocop.go
+++ b/parsers/rubocop.go
@@ -11,12 +11,12 @@ import (
 // annotation levels using RuboCop's SimpleTextFormatter colors[2] as a hint.
 // [1]: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Severity
 // [2]: https://www.rubydoc.info/gems/rubocop/RuboCop/Formatter/SimpleTextFormatter#COLOR_FOR_SEVERITY-constant
-var rubocopSeverityMapping = map[string]string{
-	"refactor":   "notice",
-	"convention": "notice",
-	"warning":    "warning",
-	"error":      "failure",
-	"fatal":      "failure",
+var rubocopSeverityMapping = map[string]model.AnnotationLevel{
+	"refactor":   model.LevelNotice,
+	"convention": model.LevelNotice,
+	"warning":    model.LevelWarning,
+	"error":      model.LevelFailure,
+	"fatal":      model.LevelFailure,
 }
 
 type rubocopLocation struct {
@@ -70,7 +70,7 @@ func ParseRuboCopAnnotations(path string) (error, []model.Annotation) {
 
 			// No matter the severity, corrected offenses get demoted to "notice" level
 			if offense.Corrected {
-				level = "notice"
+				level = model.LevelNotice
 			}
 
 			var parsedAnnotation = model.Annotation{

--- a/parsers/rubocop_test.go
+++ b/parsers/rubocop_test.go
@@ -12,10 +12,8 @@ import (
 func Test_RuboCop_DocsExample(t *testing.T) {
 	var expectedAnnotations = []model.Annotation{
 		{
-			Type:               model.LintResultAnnotationType,
 			Level:              "notice",
 			Message:            "LineLength: Line is too long. [81/80]",
-			FullyQualifiedName: "lib/bar.rb-0",
 			Location: &model.FileLocation{
 				Path:        "lib/bar.rb",
 				StartLine:   546,
@@ -25,10 +23,8 @@ func Test_RuboCop_DocsExample(t *testing.T) {
 			},
 		},
 		{
-			Type:               model.LintResultAnnotationType,
 			Level:              "warning",
 			Message:            "UnreachableCode: Unreachable code detected.",
-			FullyQualifiedName: "lib/bar.rb-1",
 			Location: &model.FileLocation{
 				Path:        "lib/bar.rb",
 				StartLine:   15,

--- a/parsers/rubocop_test.go
+++ b/parsers/rubocop_test.go
@@ -12,7 +12,7 @@ import (
 func Test_RuboCop_DocsExample(t *testing.T) {
 	var expectedAnnotations = []model.Annotation{
 		{
-			Level:              "notice",
+			Level:              model.LevelNotice,
 			Message:            "LineLength: Line is too long. [81/80]",
 			Location: &model.FileLocation{
 				Path:        "lib/bar.rb",
@@ -23,7 +23,7 @@ func Test_RuboCop_DocsExample(t *testing.T) {
 			},
 		},
 		{
-			Level:              "warning",
+			Level:              model.LevelWarning,
 			Message:            "UnreachableCode: Unreachable code detected.",
 			Location: &model.FileLocation{
 				Path:        "lib/bar.rb",

--- a/parsers/rubocop_test.go
+++ b/parsers/rubocop_test.go
@@ -12,8 +12,8 @@ import (
 func Test_RuboCop_DocsExample(t *testing.T) {
 	var expectedAnnotations = []model.Annotation{
 		{
-			Level:              model.LevelNotice,
-			Message:            "LineLength: Line is too long. [81/80]",
+			Level:   model.LevelNotice,
+			Message: "LineLength: Line is too long. [81/80]",
 			Location: &model.FileLocation{
 				Path:        "lib/bar.rb",
 				StartLine:   546,
@@ -23,8 +23,8 @@ func Test_RuboCop_DocsExample(t *testing.T) {
 			},
 		},
 		{
-			Level:              model.LevelWarning,
-			Message:            "UnreachableCode: Unreachable code detected.",
+			Level:   model.LevelWarning,
+			Message: "UnreachableCode: Unreachable code detected.",
 			Location: &model.FileLocation{
 				Path:        "lib/bar.rb",
 				StartLine:   15,

--- a/parsers/xclogparser.go
+++ b/parsers/xclogparser.go
@@ -23,7 +23,7 @@ type xclogparserReport struct {
 	Notes    []xclogparserEntry
 }
 
-func (entry *xclogparserEntry) ToAnnotation(level string) model.Annotation {
+func (entry *xclogparserEntry) ToAnnotation(level model.AnnotationLevel) model.Annotation {
 	return model.Annotation{
 		Level:      level,
 		Message:    entry.Title,
@@ -58,7 +58,7 @@ func ParseXclogparserAnnotations(path string) (error, []model.Annotation) {
 				continue
 			}
 
-			result = append(result, reportError.ToAnnotation("failure"))
+			result = append(result, reportError.ToAnnotation(model.LevelFailure))
 		}
 
 		for _, reportWarning := range report.Warnings {
@@ -66,7 +66,7 @@ func ParseXclogparserAnnotations(path string) (error, []model.Annotation) {
 				continue
 			}
 
-			result = append(result, reportWarning.ToAnnotation("warning"))
+			result = append(result, reportWarning.ToAnnotation(model.LevelWarning))
 		}
 
 		for _, reportNote := range report.Notes {
@@ -74,7 +74,7 @@ func ParseXclogparserAnnotations(path string) (error, []model.Annotation) {
 				continue
 			}
 
-			result = append(result, reportNote.ToAnnotation("notice"))
+			result = append(result, reportNote.ToAnnotation(model.LevelNotice))
 		}
 	}
 

--- a/parsers/xclogparser_test.go
+++ b/parsers/xclogparser_test.go
@@ -11,7 +11,7 @@ import (
 func TestXclogparser(t *testing.T) {
 	expected := []model.Annotation{
 		{
-			Level:   "failure",
+			Level:   model.LevelFailure,
 			Message: "Cannot find 'printeh' in scope",
 			RawDetails: `/var/folders/sr/b58hwhtj0jbcf4r09zmg0wlc0000gn/T/cirrus-ci-build/noapp/main.swift:3:1: error: cannot find 'printeh' in scope
 printeh("Hello, World!")


### PR DESCRIPTION
This removes mostly unused fields and makes annotation `level` typed in the preparation for the #32.

There were cases when `fatal` level was used, yet GitHub API [only documents](https://docs.github.com/en/rest/reference/checks#annotations-items) and `notice`, `warning`, and `failure`.