### PR TITLE
Fix inneffectual assignment in ValidateAnnotations()

### DIFF
--- a/annotations.go
+++ b/annotations.go
@@ -34,8 +34,7 @@ func ParseAnnotations(format string, path string) (error, []model.Annotation) {
 	}
 }
 
-// Makes sure that locations has validate relative to workDirPath path
-func ValidateAnnotations(workDirPath string, annotations []model.Annotation) ([]model.Annotation, error) {
+func NormalizeAnnotations(workDirPath string, annotations []model.Annotation) ([]model.Annotation, error) {
 	var result []model.Annotation
 
 	fileIndex := make(map[string]string)

--- a/annotations_test.go
+++ b/annotations_test.go
@@ -19,7 +19,7 @@ func TestValidateAnnotations(t *testing.T) {
 		},
 	}
 
-	processedAnnotations, err := annotations.ValidateAnnotations("testdata", rawAnnotations)
+	processedAnnotations, err := annotations.NormalizeAnnotations("testdata", rawAnnotations)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
To fix the bug introduced in 08b05084cd7ce623ee5ff559b5b9491a1144aa32 that caused `Path` field not to update (because the `annotation` was a copy and not a reference):

https://github.com/cirruslabs/cirrus-ci-annotations/blob/8d7c2ca610b13cba3fd32c0bb8a4855eb5cc1579/annotations.go#L60