### PR TITLE
Add support for boost (c++) test xml format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This module helps Cirrus CI to parse artifacts and find relative annotations to 
   * [XCLogParser](https://github.com/spotify/XCLogParser)
 * [JetBrains Qodana](https://github.com/JetBrains/Qodana)
 * [ESLint](https://eslint.org/)
+* [Boost](https://www.boost.org/doc/libs/1_77_0/libs/test/doc/html/boost_test/test_output/log_formats/log_xml_format.html)
 
 [Create an issue](https://github.com/cirruslabs/cirrus-ci-annotations/issues/new) to request support for other formats.
 

--- a/annotations.go
+++ b/annotations.go
@@ -31,6 +31,8 @@ func ParseAnnotations(format string, path string) (error, []model.Annotation) {
 		return parsers.ParseFlutterAnnotations(path)
 	case "cirrus":
 		return parsers.ParseCirrusAnnotations(path)
+	case "boost":
+		return parsers.ParseBoostAnnotations(path)
 	default:
 		return nil, make([]model.Annotation, 0)
 	}

--- a/parsers/boost.go
+++ b/parsers/boost.go
@@ -1,0 +1,68 @@
+package parsers
+
+import (
+	"encoding/xml"
+	"io/ioutil"
+
+	"github.com/cirruslabs/cirrus-ci-annotations/model"
+)
+
+type BoostTestError struct {
+	XMLName xml.Name `xml:"Error"`
+	File    string   `xml:"file,attr"`
+	Line    int64    `xml:"line,attr"`
+	Message string   `xml:",chardata"`
+}
+
+type BoostTestCase struct {
+	XMLName xml.Name         `xml:"TestCase"`
+	Name    string           `xml:"name,attr"`
+	File    string           `xml:"file,attr"`
+	Line    int64            `xml:"line,attr"`
+	Errors  []BoostTestError `xml:"Error"`
+}
+
+type BoostTestSuite struct {
+	XMLName   xml.Name         `xml:"TestSuite"`
+	Suites    []BoostTestSuite `xml:"TestSuite"`
+	TestCases []BoostTestCase  `xml:"TestCase"`
+}
+
+func findTestCases(suite *BoostTestSuite) []model.Annotation {
+	var annotations []model.Annotation
+	for _, s := range suite.Suites {
+		annotations = append(annotations, findTestCases(&s)...)
+	}
+	for _, testCase := range suite.TestCases {
+		for _, testError := range testCase.Errors {
+			annotations = append(annotations, model.Annotation{
+				Level:     model.LevelFailure,
+				Message:   testError.Message,
+				Path:      testError.File,
+				StartLine: testError.Line,
+				EndLine:   testError.Line,
+			})
+		}
+	}
+	return annotations
+}
+
+func ParseBoostAnnotations(path string) (error, []model.Annotation) {
+	type suites struct {
+		XMLName xml.Name         `xml:"TestLog"`
+		Suites  []BoostTestSuite `xml:"TestSuite"`
+	}
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err, nil
+	}
+	results := &suites{}
+	if err = xml.Unmarshal(b, results); err != nil {
+		return err, nil
+	}
+	var annotations []model.Annotation
+	for _, suite := range results.Suites {
+		annotations = append(annotations, findTestCases(&suite)...)
+	}
+	return nil, annotations
+}

--- a/parsers/boost_test.go
+++ b/parsers/boost_test.go
@@ -1,0 +1,43 @@
+package parsers
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cirruslabs/cirrus-ci-annotations/model"
+	"github.com/go-test/deep"
+)
+
+func TestParseBoostAnnotations(t *testing.T) {
+	err, annotations := ParseBoostAnnotations(filepath.Join("..", "testdata", "boost", "testlog.xml"))
+	if err != nil {
+		t.Errorf("Errored: %v", err)
+	}
+	if len(annotations) != 2 {
+		t.Errorf("Wrong amount of annotations: %v", len(annotations))
+	}
+	expected := model.Annotation{
+		Level:      model.LevelFailure,
+		Message:    "an error happened",
+		RawDetails: "",
+		Path:       "test/boost_tests.cpp",
+		StartLine:  130,
+		EndLine:    130,
+	}
+	if diff := deep.Equal(expected, annotations[0]); diff != nil {
+		t.Error(diff)
+	}
+
+	expected = model.Annotation{
+		Level:      model.LevelFailure,
+		Message:    "another error",
+		RawDetails: "",
+		Path:       "test/boost_tests2.cpp",
+		StartLine:  230,
+		EndLine:    230,
+	}
+	if diff := deep.Equal(expected, annotations[1]); diff != nil {
+		t.Error(diff)
+	}
+
+}

--- a/testdata/boost/testlog.xml
+++ b/testdata/boost/testlog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<TestLog>
+    <TestSuite name="Test Suite">
+        <TestSuite name="boost_tests" file="test/boost_tests.cpp" line="124">
+            <TestCase name="boost_sample" file="test/boost_tests.cpp" line="126">
+                <Error file="test/boost_tests.cpp" line="130"><![CDATA[an error happened]]></Error>
+            </TestCase>
+        </TestSuite>
+        <TestSuite name="boost_tests2" file="test/boost_tests2.cpp" line="224">
+            <TestCase name="boost_sample2" file="test/boost_tests2.cpp" line="226">
+                <Error file="test/boost_tests2.cpp" line="230"><![CDATA[another error]]></Error>
+            </TestCase>
+        </TestSuite>
+    </TestSuite>
+</TestLog>


### PR DESCRIPTION
You can see example output [here](https://api.cirrus-ci.com/v1/artifact/task/6388041557213184/boost_test_log/ci/scratch/build/bitcoin-x86_64-pc-linux-gnu/src/test/addrman_tests.cpp_testlog.xml)  for [this](https://cirrus-ci.com/task/6388041557213184)  job